### PR TITLE
move contributors to separate file and update config

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,12 +1,17 @@
 {
   "projectName": "aok",
   "projectOwner": "icesat2py",
-  "files": [
-    "README.md"
-  ],
   "commitType": "docs",
   "commitConvention": "angular",
   "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": true,
+  "files": [
+    "CONTRIBUTORS.rst"
+  ],
+  "imageSize": 100,
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "skipCi": true,
   "contributors": [
     {
       "login": "kelseybisson",

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,25 @@
+Project Contributors
+--------------------
+
+The following people have made contributions to this project (in alphabetical order).
+Thanks goes to these wonderful people (`emoji key <https://allcontributors.org/docs/en/emoji-key>`_):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="http://bisson.work"><img src="https://avatars.githubusercontent.com/u/48059682?v=4?s=100" width="100px;" alt="Kelsey Bisson"/><br /><sub><b>Kelsey Bisson</b></sub></a><br /><a href="#code-kelseybisson" title="Code">💻</a> <a href="#ideas-kelseybisson" title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://blogs.oregonstate.edu/coastalseds/"><img src="https://avatars.githubusercontent.com/u/130190809?v=4?s=100" width="100px;" alt="Emily Eidam"/><br /><sub><b>Emily Eidam</b></sub></a><br /><a href="#code-emilyeidam" title="Code">💻</a> <a href="#fundingFinding-emilyeidam" title="Funding Finding">🔍</a> <a href="#ideas-emilyeidam" title="Ideas, Planning, & Feedback">🤔</a> <a href="#projectManagement-emilyeidam" title="Project Management">📆</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/gloverha"><img src="https://avatars.githubusercontent.com/u/105296359?v=4?s=100" width="100px;" alt="Hannah Glover"/><br /><sub><b>Hannah Glover</b></sub></a><br /><a href="#code-gloverha" title="Code">💻</a> <a href="#ideas-gloverha" title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/JessicaS11"><img src="https://avatars.githubusercontent.com/u/11756442?v=4?s=100" width="100px;" alt="Jessica Scheick"/><br /><sub><b>Jessica Scheick</b></sub></a><br /><a href="#code-JessicaS11" title="Code">💻</a> <a href="#ideas-JessicaS11" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-JessicaS11" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#maintenance-JessicaS11" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ChaoEcohydroRS"><img src="https://avatars.githubusercontent.com/u/30786839?v=4?s=100" width="100px;" alt="Chao"/><br /><sub><b>Chao</b></sub></a><br /><a href="#code-ChaoEcohydroRS" title="Code">💻</a> <a href="#ideas-ChaoEcohydroRS" title="Ideas, Planning, & Feedback">🤔</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,7 +2,7 @@ Project Contributors
 --------------------
 
 The following people have made contributions to this project (in alphabetical order).
-Thanks goes to these wonderful people (`emoji key <https://allcontributors.org/docs/en/emoji-key>`_):
+Thanks goes to these wonderful people [emoji key](https://allcontributors.org/docs/en/emoji-key):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ ATLAS Ocean Kd (AOK) - calculating ocean Kd values using ICESat-2
 > This package is currently under active development to produce the most reliable calculations of Kd values.
 > The code is therefore unstable, may have significant uncertainties, and should be used with caution.
 
+[![All Contributors](https://img.shields.io/github/all-contributors/icesat2py/aok?color=ee8449&style=flat-square)](#contributors)
+
 # Quickstart
 
 ## Calculating Kd
@@ -35,5 +37,5 @@ Some guidelines on [ways to contribute](https://icepyx.readthedocs.io/en/latest/
 Our full attribution guidelines are coming soon.
 
 We use the [All Contributors Specification](https://allcontributors.org/docs/en/specification)
-to recognize our incredible [contributor team](CONTRIBUTORS.rst).
+to recognize our incredible [contributor team](CONTRIBUTORS.md).
 

--- a/README.md
+++ b/README.md
@@ -35,27 +35,5 @@ Some guidelines on [ways to contribute](https://icepyx.readthedocs.io/en/latest/
 Our full attribution guidelines are coming soon.
 
 We use the [All Contributors Specification](https://allcontributors.org/docs/en/specification)
-to recognize our incredible contributor team.
-
-### Contributors
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tbody>
-    <tr>
-      <td align="center" valign="top" width="14.28%"><a href="http://bisson.work"><img src="https://avatars.githubusercontent.com/u/48059682?v=4?s=100" width="100px;" alt="Kelsey Bisson"/><br /><sub><b>Kelsey Bisson</b></sub></a><br /><a href="#code-kelseybisson" title="Code">💻</a> <a href="#ideas-kelseybisson" title="Ideas, Planning, & Feedback">🤔</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://blogs.oregonstate.edu/coastalseds/"><img src="https://avatars.githubusercontent.com/u/130190809?v=4?s=100" width="100px;" alt="Emily Eidam"/><br /><sub><b>Emily Eidam</b></sub></a><br /><a href="#code-emilyeidam" title="Code">💻</a> <a href="#fundingFinding-emilyeidam" title="Funding Finding">🔍</a> <a href="#ideas-emilyeidam" title="Ideas, Planning, & Feedback">🤔</a> <a href="#projectManagement-emilyeidam" title="Project Management">📆</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/gloverha"><img src="https://avatars.githubusercontent.com/u/105296359?v=4?s=100" width="100px;" alt="Hannah Glover"/><br /><sub><b>Hannah Glover</b></sub></a><br /><a href="#code-gloverha" title="Code">💻</a> <a href="#ideas-gloverha" title="Ideas, Planning, & Feedback">🤔</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/JessicaS11"><img src="https://avatars.githubusercontent.com/u/11756442?v=4?s=100" width="100px;" alt="Jessica Scheick"/><br /><sub><b>Jessica Scheick</b></sub></a><br /><a href="#code-JessicaS11" title="Code">💻</a> <a href="#ideas-JessicaS11" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-JessicaS11" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#maintenance-JessicaS11" title="Maintenance">🚧</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ChaoEcohydroRS"><img src="https://avatars.githubusercontent.com/u/30786839?v=4?s=100" width="100px;" alt="Chao"/><br /><sub><b>Chao</b></sub></a><br /><a href="#code-ChaoEcohydroRS" title="Code">💻</a> <a href="#ideas-ChaoEcohydroRS" title="Ideas, Planning, & Feedback">🤔</a></td>
-    </tr>
-  </tbody>
-</table>
-
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
-
-<!-- ALL-CONTRIBUTORS-LIST:END -->
+to recognize our incredible [contributor team](CONTRIBUTORS.rst).
 


### PR DESCRIPTION
We needed to use the all-contributors bot before we could move the contributors list to a separate file (versus in the readme). This PR makes that change and updates a few other settings that also required an initial usage.